### PR TITLE
Make it possible to set the planning scene used.

### DIFF
--- a/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/ikfast_moveit_state_adapter.h
@@ -46,6 +46,14 @@ public:
    */
   void setState(const moveit::core::RobotState& state);
 
+  /**
+   * @brief Set the planning scene based on message. This also sets the robot model.
+   * transforms are recomputed.
+   * 
+   * @param planning_scene 
+   */
+  void setPlanningScene(const moveit_msgs::PlanningScene &planning_scene);
+
 protected:
   bool computeIKFastTransforms();
 

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -96,6 +96,15 @@ public:
    */
   void setState(const moveit::core::RobotState &state);
 
+  /**
+   * @brief Set the planning scene used in this model to be the one described in the message.
+   *        Useful for planning with a scene that has been updated since it was loaded from a
+   *        urdf file
+   * 
+   * @param planning_scene 
+   */
+  void setPlanningScene(const moveit_msgs::PlanningScene &planning_scene);
+
 protected:
   /**
    * Gets IK solution (assumes robot state is pre-seeded)

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -146,6 +146,12 @@ void descartes_moveit::IkFastMoveitStateAdapter::setState(const moveit::core::Ro
   computeIKFastTransforms();
 }
 
+void descartes_moveit::IkFastMoveitStateAdapter::setPlanningScene(const moveit_msgs::PlanningScene& planning_scene)
+{
+  descartes_moveit::MoveitStateAdapter::setPlanningScene(planning_scene);
+  computeIKFastTransforms();
+}
+
 bool descartes_moveit::IkFastMoveitStateAdapter::computeIKFastTransforms()
 {
   // look up the IKFast base and tool frame

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -249,10 +249,10 @@ bool MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) co
   bool in_collision = false;
   if (check_collisions_)
   {
-    moveit::core::RobotState state (robot_model_ptr_);
+    moveit::core::RobotState state (planning_scene_->getCurrentState());
     state.setToDefaultValues();
     state.setJointGroupPositions(joint_group_, joint_pose);
-    in_collision = planning_scene_->isStateColliding(state, group_name_);
+    in_collision = planning_scene_->isStateColliding(state);
   }
   return in_collision;
 }
@@ -341,6 +341,12 @@ void MoveitStateAdapter::setState(const moveit::core::RobotState& state)
                                                   "initialize()?");
   *robot_state_ = state;
   planning_scene_->setCurrentState(state);
+}
+
+void MoveitStateAdapter::setPlanningScene(const moveit_msgs::PlanningScene &planning_scene)
+{
+  planning_scene_->setPlanningSceneMsg(planning_scene);
+  *robot_state_ = planning_scene_->getCurrentState();
 }
 
 }  // descartes_moveit


### PR DESCRIPTION
Collision checking will now use the robot state from the planning scene as the basis (in particular, attached collision objects here will be respected).
Collision checking is no longer only done for the group used for planning.

A bit more work is probably still needed here. Also would be nice to get rid of some of the compiler warnings while we are working on this anyways.